### PR TITLE
upgrade-torch

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -13,7 +13,14 @@ from transformers import CLIPProcessor, CLIPModel
 import torch
 
 # Load the CLIP model and processor once
-clip_model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+clip_model = CLIPModel.from_pretrained(
+	"openai/clip-vit-base-patch32",
+	subfolder="",
+	local_files_only=False,
+	trust_remote_code=False,
+	token=None,
+	use_safetensors=True  # <-- Force safetensors only
+)
 clip_processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
 
 DATA_PATH = "data/known_dogs.pkl"

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,9 +38,11 @@ uv venv .venv
 source .venv/bin/activate
 ```
 
-### 3. Install dependencies
+### 3. Install dependencie
+Includes fix for nasty bug in torch :(s
 ```bash
 uv pip install -e '.[dev]'
+uv pip install --index-url https://download.pytorch.org/whl/cpu torch==2.2.2
 ```
 
 ### 4. Set your OpenAI API key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "scipy",
   "transformers",
   "torch",
+  "safetensors",
   "python-multipart"
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
## Description
There are lots of problems with torch, due to the vulnerability report [32434](https://nvd.nist.gov/vuln/detail/CVE-2025-32434) .

## Changes
After quite a bit of p*ssing about, I've added safetensors, then when I call the from_pretrained() method, I tell transformers to refuse to load .bin files and only use .safetensors.
Yuk!
This should be revisited when torch is properly fixed.