### PR TITLE
Optimize Railway deployment to reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,71 @@
+# Git
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.venv/
+pyvenv.cfg
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Documentation
+*.md
+docs/
+
+# Local development
+run.sh
+bin/
+
+# Large model cache (transformers downloads these at runtime)
+.cache/
+*.bin
+*.safetensors
+models/
+transformers_cache/

--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,55 @@
+# Railway ignore file to reduce deployment size
+
+# Git
+.git/
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+
+# Virtual environments  
+.venv/
+venv/
+env/
+ENV/
+pyvenv.cfg
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation
+*.md
+docs/
+
+# Local dev files
+run.sh
+bin/
+
+# Model cache (downloaded at runtime)
+.cache/
+models/
+transformers_cache/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,45 +1,30 @@
-# 🚀 Deployment Guide
+# 🚀 Railway Deployment Guide
 
-This guide shows how to deploy your Dog Identifier app to the cloud with multiple hosting options.
+Deploy your Dog Identifier app to Railway for instant cloud hosting.
 
 ## 🏗️ What's Included
 
 - **Mobile-friendly web frontend** (`frontend/index.html`)
 - **Cloud-ready FastAPI backend** with health checks
-- **Multiple deployment configs** (Railway, Heroku, Docker)
+- **Railway configuration** (`railway.toml`) for seamless deployment
 
-## ⚡ Quick Deploy Options
+## ⚡ Deploy to Railway
 
-### Option 1: Railway (Recommended)
-Railway is the easiest way to deploy Python apps.
+Railway automatically detects Python projects and handles everything for you.
 
-1. Install Railway CLI:
+1. **Install Railway CLI:**
    ```bash
    npm install -g @railway/cli
    ```
 
-2. Login and deploy:
+2. **Login and deploy:**
    ```bash
    railway login
    railway init
    railway up
    ```
 
-3. Your app will be available at: `https://your-app.railway.app`
-
-### Option 2: Heroku
-1. Install Heroku CLI and login
-2. Create and deploy:
-   ```bash
-   heroku create your-dog-identifier
-   heroku stack:set container
-   git add .
-   git commit -m "Deploy to Heroku"
-   git push heroku main
-   ```
-
-### Option 3: Any Docker Platform
-Use the provided `Dockerfile` with any platform that supports Docker (Render, Fly.io, etc.)
+3. **Your app will be live!** Railway provides a URL like: `https://your-app.railway.app`
 
 ## 🔧 Configuration
 
@@ -47,43 +32,46 @@ Use the provided `Dockerfile` with any platform that supports Docker (Render, Fl
 After deployment, update the API URL in `frontend/index.html`:
 
 ```javascript
-const API_BASE_URL = 'https://your-deployed-backend-url.com';
+const API_BASE_URL = 'https://your-app-name.railway.app';
 ```
 
-### Environment Variables
-No environment variables required - the app uses the local CLIP model.
+Replace `your-app-name` with your actual Railway app URL.
+
+### No Environment Variables Needed
+The app uses the local CLIP model, so no external API keys are required.
 
 ## 📱 Using Your App
 
-1. **Access your app** at your deployed URL
-2. **Take/upload photos** to identify dogs
+1. **Access your app** at your Railway URL
+2. **Take/upload photos** to identify dogs  
 3. **Add new dogs** to expand the database
-4. **Share the URL** - it works on any mobile device!
+4. **Works on any mobile device** - fully responsive!
 
 ## 🛠️ Local Development
 
 ```bash
-# Backend only
+# Run backend locally
 ./run.sh
 
-# Test frontend locally
+# Test frontend locally  
 python -m http.server 8080 -d frontend
-# Then visit: http://localhost:8080
+# Visit: http://localhost:8080
 ```
 
 ## 📊 Monitoring
 
-- Health check endpoint: `/health`
-- Check deployment logs via your platform's dashboard
-- Monitor response times and errors
+- **Health check:** `/health` endpoint
+- **Railway dashboard:** Monitor logs and performance
+- **Automatic restarts:** Configured in `railway.toml`
 
 ## 🔄 Updates
 
-To update your deployed app:
+Railway automatically redeploys when you push to GitHub:
+
 ```bash
 git add .
-git commit -m "Update app"
+git commit -m "Update app"  
 git push
 ```
 
-Your platform will automatically redeploy!
+Your changes will be live in minutes!

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,10 @@
-[build]
-builder = "dockerfile"
-
 [deploy]
 startCommand = "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
-healthcheckPath = "/"
+healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "always"
+
+[env]
+TRANSFORMERS_CACHE = "/tmp/transformers_cache"
+HF_HOME = "/tmp/hf_cache"
+TORCH_HOME = "/tmp/torch_cache"


### PR DESCRIPTION
- Add .dockerignore and .railwayignore to exclude cache files
- Configure model cache to use /tmp directories
- Update deployment docs to focus on Railway-only workflow
- Remove references to Docker/Heroku options

🤖 Generated with [Claude Code](https://claude.ai/code)